### PR TITLE
Fix typescript scoring system errors

### DIFF
--- a/src/components/ScoringSystem.tsx
+++ b/src/components/ScoringSystem.tsx
@@ -2,47 +2,45 @@ import { AtBatOutcome, getOutcomePoints } from '../lib/types'
 
 export const ScoringSystem = () => {
   const outcomes: AtBatOutcome[] = [
-    'home_run', 'triple', 'double', 'single', 'walk', 'strikeout', 'groundout', 'flyout', 'popout', 'lineout', 'fielders_choice', 'hit_by_pitch', 'error', 'sacrifice', 'other'
+    'home_run', 'triple', 'double', 'single', 'walk', 'strikeout', 'field_out', 'fielders_choice', 'hit_by_pitch', 'field_error', 'sac_fly', 'sac_bunt', 'double_play', 'other_out'
   ]
 
   const getOutcomeLabel = (outcome: AtBatOutcome): string => {
-    const labels: Record<AtBatOutcome, string> = {
+    const labels: Partial<Record<AtBatOutcome, string>> = {
       'home_run': 'Home Run',
       'triple': 'Triple',
       'double': 'Double',
       'single': 'Single',
       'walk': 'Walk',
       'strikeout': 'Strikeout',
-      'groundout': 'Groundout',
-      'flyout': 'Flyout',
-      'popout': 'Popout',
-      'lineout': 'Lineout',
+      'field_out': 'Out',
       'fielders_choice': "Fielder's Choice",
       'hit_by_pitch': 'Hit by Pitch',
-      'error': 'Error',
-      'sacrifice': 'Sacrifice',
-      'other': 'Other'
+      'field_error': 'Error',
+      'sac_fly': 'Sacrifice Fly',
+      'sac_bunt': 'Sacrifice Bunt',
+      'double_play': 'Double Play',
+      'other_out': 'Other Out'
     }
     return labels[outcome] || outcome
   }
 
   const getOutcomeEmoji = (outcome: AtBatOutcome): string => {
-    const emojis: Record<AtBatOutcome, string> = {
+    const emojis: Partial<Record<AtBatOutcome, string>> = {
       'home_run': '💥',
       'triple': '🏃🏃🏃',
       'double': '🏃🏃',
       'single': '🏃',
       'walk': '🚶',
       'strikeout': '❌',
-      'groundout': '⚾',
-      'flyout': '✈️',
-      'popout': '⬆️',
-      'lineout': '📏',
+      'field_out': '⚾',
       'fielders_choice': '🤔',
       'hit_by_pitch': '💢',
-      'error': '😅',
-      'sacrifice': '🙏',
-      'other': '❓'
+      'field_error': '😅',
+      'sac_fly': '🙏',
+      'sac_bunt': '🙏',
+      'double_play': '2️⃣',
+      'other_out': '❓'
     }
     return emojis[outcome] || '❓'
   }
@@ -109,16 +107,24 @@ export const ScoringSystem = () => {
           <h4 className="text-purple-300 font-medium mb-2">⚡ Risk & Reward</h4>
           <div className="text-gray-300 text-sm space-y-2">
             <div className="flex items-center space-x-2">
-              <span className="text-green-400">+50% Bonus:</span>
-              <span>Home Run, Triple (rare outcomes)</span>
+              <span className="text-green-400">+100% Bonus:</span>
+              <span>Home Run</span>
             </div>
             <div className="flex items-center space-x-2">
-              <span className="text-blue-400">+25% Bonus:</span>
-              <span>Double (uncommon outcome)</span>
+              <span className="text-blue-400">+80% Bonus:</span>
+              <span>Triple</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <span className="text-blue-400">+50% Bonus:</span>
+              <span>Double</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <span className="text-blue-400">+20% Bonus:</span>
+              <span>Single</span>
             </div>
             <div className="flex items-center space-x-2">
               <span className="text-gray-400">No Bonus:</span>
-              <span>Single, Walk, Strikeout, Outs (common outcomes)</span>
+              <span>Walk, Strikeout, Outs (common outcomes)</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Update `ScoringSystem.tsx` to use valid `AtBatOutcome` values and correct scoring system descriptions to resolve TypeScript build errors.

The build was failing due to `TS2322` and `TS2353` errors caused by using string literals (e.g., `'groundout'`, `'error'`) that were not defined in the `AtBatOutcome` type. This PR aligns the outcomes used in `ScoringSystem.tsx` with the actual `AtBatOutcome` enum values (e.g., `'field_out'`, `'field_error'`), makes the label/emoji maps `Partial` for flexibility, and updates the "Risk & Reward" section to accurately reflect point multipliers.

---
<a href="https://cursor.com/background-agent?bcId=bc-9caa91d9-2522-47e4-b55a-8651c47317d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9caa91d9-2522-47e4-b55a-8651c47317d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

