### PR TITLE
Verify mariners team ID for game display

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -143,7 +143,7 @@ npm run dev
 
 The app uses the MLB Stats API:
 - Base URL: `https://statsapi.mlb.com/api/v1`
-- Mariners Team ID: `112`
+- Mariners Team ID: `136`
 - Updates every 10 seconds during live games
 
 ## Real-time Features

--- a/api/mlb/game-state.ts
+++ b/api/mlb/game-state.ts
@@ -1,6 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 
-const MARINERS_TEAM_ID = 133
+const MARINERS_TEAM_ID = 136
 const MLB_BASE_URL = 'https://statsapi.mlb.com/api/v1'
 const MLB_GAME_FEED_URL = 'https://statsapi.mlb.com/api/v1.1'
 

--- a/api/mlb/refresh-cache.ts
+++ b/api/mlb/refresh-cache.ts
@@ -1,6 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 
-const MARINERS_TEAM_ID = 133
+const MARINERS_TEAM_ID = 136
 const MLB_BASE_URL = 'https://statsapi.mlb.com/api/v1'
 const MLB_GAME_FEED_URL = 'https://statsapi.mlb.com/api/v1.1'
 

--- a/api/mlb/schedule.ts
+++ b/api/mlb/schedule.ts
@@ -1,6 +1,6 @@
 import { VercelRequest, VercelResponse } from '@vercel/node'
 
-const MARINERS_TEAM_ID = 133
+const MARINERS_TEAM_ID = 136
 const MLB_BASE_URL = 'https://statsapi.mlb.com/api/v1'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/src/components/GameState.tsx
+++ b/src/components/GameState.tsx
@@ -64,7 +64,7 @@ export const GameState = ({ gameState, isLiveMode }: GameStateWithToggleProps) =
     )
   }
   
-  const isMarinersHome = homeTeamId === 133
+  const isMarinersHome = homeTeamId === 136
   const marinersTeam = isMarinersHome ? homeTeam : awayTeam
   const opponentTeam = isMarinersHome ? awayTeam : homeTeam
 

--- a/src/lib/mlbService.ts
+++ b/src/lib/mlbService.ts
@@ -1,6 +1,6 @@
 import { MLBGame, MLBPlay, GameState } from './types'
 
-const MARINERS_TEAM_ID = 133 // Seattle Mariners team ID in MLB API
+const MARINERS_TEAM_ID = 136 // Seattle Mariners team ID in MLB API
 
 class MLBService {
   private apiBaseUrl: string


### PR DESCRIPTION
Update Mariners team ID to 136 to correctly display Mariners games instead of Phillies games.

---
<a href="https://cursor.com/background-agent?bcId=bc-0edaadee-a02f-42f9-b1eb-7435e384402f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0edaadee-a02f-42f9-b1eb-7435e384402f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

